### PR TITLE
640px 以下でヘッダー下メニューを隠す.

### DIFF
--- a/sass/common/_mixins.scss
+++ b/sass/common/_mixins.scss
@@ -1,0 +1,20 @@
+// X px 以下で適用
+@mixin max-screen($break-point) {
+  @media screen and (max-width: $break-point) {
+    @content;
+  }
+}
+
+// X px 以上で適用
+@mixin min-screen($break-point) {
+  @media screen and (min-width: $break-point) {
+    @content;
+  }
+}
+
+// X px 以上、Y px 以下で適用
+@mixin screen($break-point-min, $break-point-max) {
+  @media screen and (min-width: $break-point-min) and (max-width: $break-point-max) {
+    @content;
+  }
+}

--- a/sass/common/_valiables.scss
+++ b/sass/common/_valiables.scss
@@ -1,3 +1,5 @@
 $nav-base: #eee; //Navカラー
 
 $nav-hover: #808080; //Navカラーhover
+
+$breakpoint-mobile: 640px; //Break Point, これ以下の時は Mobile View

--- a/sass/components/_nav.scss
+++ b/sass/components/_nav.scss
@@ -22,5 +22,9 @@
         width: 110px;
         height: 50px;
     }
+    // $breakpoint-mobile px 以下で適用
+    @include max-screen($breakpoint-mobile) {
+        display: none;
+    }
 }
 

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -7,6 +7,9 @@
 /* valiables */
 @import "common/valiables";
 
+/* mix in */
+@import "common/mixins";
+
 /* common */
 @import "common/common";
 


### PR DESCRIPTION
`$breakpoint-mobile: 640px;` を `_valiables.scss` に定義しました。
また、レスポンシブ用の `mixin` を `_mixin.scss` に定義しました。

これを `_nav.scss` で書き足したように使用することで、
画面幅によって適用をコントロールするようなスタイルを実現できます。

今回の修正では、 **画面を640px以下にした時に、ヘッダーしたのメニューに `display: none;` を適用する** ようにしました。